### PR TITLE
Fixed ASCII simlib output unit of RA, DEC

### DIFF
--- a/example/WritingOutSimlibs.ipynb
+++ b/example/WritingOutSimlibs.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:589b21c949f29f19c2b623e32929377549e0cf9e3fe48e2c52b7210d71fb38ff"
+  "signature": "sha256:b5b23747c946d000efc5d8ad172f7a6e16470bff2758b9064ae66ebb2291442d"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -54,7 +54,7 @@
        "output_type": "stream",
        "stream": "stdout",
        "text": [
-        "/Users/rbiswas/doc/projects/supernovae/LSST/simlib/build/lib/simlibs/summarize_opsim.pyc\n"
+        "/Users/rbiswas/.local/lib/python2.7/site-packages/OpSimSummary-0.0.1.dev0-py2.7.egg/simlibs/summarize_opsim.pyc\n"
        ]
       }
      ],

--- a/simlibs/summarize_opsim.py
+++ b/simlibs/summarize_opsim.py
@@ -321,8 +321,8 @@ class SummaryOpsim(object):
     
     def fieldheader(self, fieldID):
         
-        ra = self.ra(fieldID)
-        dec = self.dec(fieldID)
+        ra = np.degrees(self.ra(fieldID))
+        dec = np.degrees(self.dec(fieldID))
         mwebv = 0.01
         pixSize = self.pixelSize 
         nobs = len(self.simlib(fieldID))


### PR DESCRIPTION
SNANA SIMLIBS use RA, DEC values in degrees, while this was being
printed out in radians. Changed the code so that the ASCII output is in
radians. Checked that this works correctly by looking at the outut and
comparing to SNANA simlibs.

modified:   ./simlibs/summarize_opsim.py

modified:   WritingOutSimlibs.ipynb
    Nothing really modified