### PR TITLE
Loosenfield id dependence

### DIFF
--- a/OpSimSummary/summarize_opsim.py
+++ b/OpSimSummary/summarize_opsim.py
@@ -110,7 +110,7 @@ class SummaryOpsim(object):
         import subprocess
 
         self.df = summarydf.copy(deep=True)
-        self.df['MJDay'] = self.calcMJDay(self.df)
+        self.calcMJDay(self.df)
         if 'simLibSkySig' not in self.df.columns:
             self.df  = add_simlibCols(self.df)
 
@@ -304,7 +304,7 @@ class SummaryOpsim(object):
         # Extend to all values in plot
         Matrix = M.reindex(ss, fill_value=np.nan)
 
-        return Matrix #, X
+        return Matrix
 
 
     @staticmethod


### PR DESCRIPTION
Previous versions of OpSimSummary required having a fieldID for constructing `summarize_opsim.cadence_Matrix` and `summarize_opsim.cadence_plot` only to grab the fieldID, ra, dec values for labels. 

Instead, now there is an option of not providing a fieldID and it will look for a raCol, decCol in the summarydf and construct these labels from that information. This is to work with qualitymetrics in Cadence repository.