### PR TITLE
Put try except block around visualization import involving basemap

### DIFF
--- a/opsimsummary/__init__.py
+++ b/opsimsummary/__init__.py
@@ -8,4 +8,8 @@ from .healpix import *
 from .tessellations import *
 from .opsim_out import *
 from .healpixTiles import *
-from .visualization import *
+try:
+    from .visualization import *
+except:
+    print('Visulization functions based on maps will not work')
+    pass


### PR DESCRIPTION
	modified:   opsimsummary/__init__.py
wrapping the import of objects from visualization.py in a try, except block temporarily. Fixes #90 