### PR TITLE
Change the default value of `mwebv` in `summarizeOpSim.Field`

### DIFF
--- a/opsimsummary/simlib.py
+++ b/opsimsummary/simlib.py
@@ -387,7 +387,8 @@ class Simlibs(SynOpSim, SimlibMixin):
             outfile = fname  + '.hdf'
         fields = self.sampleRegion(numFields=numFields, rng=rng,
                                    outfile=outfile, subset=self.subset,
-                                   minVisits=minVisits, nside=256)
+                                   minVisits=minVisits, nside=256,
+                                   mwebv=mwebv)
         num_fields = self.writeSimlib(fname, fields, fieldtype=fieldtype, mwebv=mwebv)
 
         fields = self.sampleRegion(numFields=numFields, rng=rng,

--- a/opsimsummary/summarize_opsim.py
+++ b/opsimsummary/summarize_opsim.py
@@ -181,7 +181,7 @@ class SynOpSim(object):
 
     def sampleRegion(self, numFields=50000, minVisits=1, nest=True, nside=256,
                      rng=np.random.RandomState(1), outfile=None,
-                     usePointingTree=True, subset='wfd'):
+                     usePointingTree=True, subset='wfd', mwebv=0.):
         """This method samples a number `numFields` fields provided they have
         a minimal number of visits `minVisits`
 
@@ -259,21 +259,23 @@ class SynOpSim(object):
         for i, fieldID in enumerate(fieldIDs):
             print(i, fieldID)
             field.setfields(fieldID, ra[i], dec[i],
-                            next(pts).sort_values(by='expMJD'))
+                            next(pts).sort_values(by='expMJD'), mwebv=mwebv)
             yield field 
 
 
 
 class Field(object):
     def __init__(self, fieldID=None, ra=None, dec=None, opsimtable=None,
-                 mwebv=0.1):
+                 mwebv=0.0):
         self.fieldID = fieldID
         self.ra = ra
         self.dec = dec
         self.mwebv = mwebv
         self.opsimtable = opsimtable
 
-    def setfields(self, fieldID, ra, dec, opsimtable):
+    def setfields(self, fieldID, ra, dec, opsimtable, mwebv=None):
+        if mwebv is None:
+            mwebv = mwebv
         self.fieldID = fieldID
         self.ra = ra
         self.dec = dec


### PR DESCRIPTION
	modified:   summarize_opsim.py

There is a call to `summarize_opsim` without specifying a value of `MWEBV`. This needs to be fixed. 
But for now, the default value of the parameter in `Field` has been fixed to 0.

Fixes #222