### PR TITLE
Fix version typo

### DIFF
--- a/opsimsummary/opsim_out.py
+++ b/opsimsummary/opsim_out.py
@@ -82,7 +82,7 @@ class OpSimOutput(object):
     def fromOpSimDB(cls, dbname, subset='combined',
                     tableNames=('Summary', 'Proposal'),
                     propIDs=None, zeroDDFDithers=True,
-                    opsimversion='lsst3'):
+                    opsimversion='lsstv3'):
         """
         Class Method to instantiate this from an OpSim sqlite
         database output


### PR DESCRIPTION
This commit fixes the small typo of the opsimdb version in fromOpSimDB default argument.

Fixes #229